### PR TITLE
Add FastMCP server with stock quote tool

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,28 +1,9 @@
-import logging
-import os
 import streamlit as st
 
-
-def _log_level():
-    level = os.getenv("LOG_LEVEL", "INFO").upper()
-    return getattr(logging, level, logging.INFO)
+from logging_utils import configure_logging
 
 
-def _configure_logging():
-    handlers = [logging.StreamHandler()]
-    dest = os.getenv("LOG_DEST")
-    if dest:
-        handlers.append(logging.FileHandler(dest))
-    logging.basicConfig(
-        level=_log_level(),
-        handlers=handlers,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-        force=True,
-    )
-    return logging.getLogger("app")
-
-
-logger = _configure_logging()
+logger = configure_logging()
 
 st.set_page_config(page_title="Hello", layout="centered")
 logger.info("App started")

--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -13,3 +13,8 @@
 ## Troubleshooting
 - If the app doesn't start, verify Python version (3.9+) and Streamlit installation.
 - Check terminal output for errors and logs.
+
+## FastMCP Server
+1. Install dependencies: `pip install -r requirements.txt`
+2. Start the server: `python mcp_server.py`
+3. The server provides a `get_stock_quote` tool that fetches prices using the free Alpha Vantage demo API.

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,21 @@
+import logging
+import os
+
+
+def _log_level() -> int:
+    level = os.getenv("LOG_LEVEL", "INFO").upper()
+    return getattr(logging, level, logging.INFO)
+
+
+def configure_logging(name: str = "app") -> logging.Logger:
+    handlers = [logging.StreamHandler()]
+    dest = os.getenv("LOG_DEST")
+    if dest:
+        handlers.append(logging.FileHandler(dest))
+    logging.basicConfig(
+        level=_log_level(),
+        handlers=handlers,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        force=True,
+    )
+    return logging.getLogger(name)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,32 @@
+import os
+import requests
+from fastmcp import FastMCP
+
+from logging_utils import configure_logging
+
+logger = configure_logging("mcp")
+server = FastMCP("Stock MCP Server")
+
+API_URL = "https://www.alphavantage.co/query"
+API_KEY = os.getenv("ALPHAVANTAGE_API_KEY", "demo")
+
+
+@server.tool()
+def get_stock_quote(symbol: str) -> dict:
+    """Fetch the latest stock quote for ``symbol`` using the Alpha Vantage demo API."""
+    params = {"function": "GLOBAL_QUOTE", "symbol": symbol, "apikey": API_KEY}
+    logger.info("Fetching quote for %s", symbol)
+    response = requests.get(API_URL, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json().get("Global Quote", {})
+    if not data:
+        return {"symbol": symbol.upper(), "price": None}
+    return {
+        "symbol": data.get("01. symbol", symbol.upper()),
+        "price": float(data.get("05. price", "0") or 0.0),
+        "change_percent": data.get("10. change percent"),
+    }
+
+
+if __name__ == "__main__":
+    server.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 streamlit
+fastmcp
+requests


### PR DESCRIPTION
## Summary
- refactor logging into reusable utility
- add FastMCP server exposing `get_stock_quote` using Alpha Vantage free API
- document and declare new dependencies

## Testing
- `python -m py_compile app.py logging_utils.py mcp_server.py`
- `pytest` *(no tests found)*
- `python - <<'PY'
from mcp_server import get_stock_quote
print(get_stock_quote.fn('IBM'))
PY` *(proxy error: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c26dfe9c83329887f4557b7fdd0d